### PR TITLE
Create singleton network interface controller class

### DIFF
--- a/FTPClientProject.csproj
+++ b/FTPClientProject.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/NIC.cs
+++ b/NIC.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace FTPClientProject
+{
+    /// <summary>
+    /// Network Interface Controller (NIC) class that represents the single network card on the machine.
+    /// Implements singleton pattern to ensure only one instance can be created.
+    /// </summary>
+    public sealed class NIC
+    {
+        // Private static instance for singleton pattern
+        private static readonly Lazy<NIC> _instance = new Lazy<NIC>(() => new NIC());
+        
+        // Private constructor to prevent external instantiation
+        private NIC()
+        {
+            // Initialize with default values
+            Manufacture = "Unknown";
+            MacAddress = "00:00:00:00:00:00";
+            Type = NetworkType.Ethernet;
+        }
+        
+        /// <summary>
+        /// Gets the single instance of the NIC class
+        /// </summary>
+        public static NIC Instance => _instance.Value;
+        
+        /// <summary>
+        /// Gets or sets the manufacturer of the network card
+        /// </summary>
+        public string Manufacture { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the MAC address of the network card
+        /// </summary>
+        public string MacAddress { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the type of network connection
+        /// </summary>
+        public NetworkType Type { get; set; }
+        
+        /// <summary>
+        /// Override ToString method to provide a readable representation of the NIC
+        /// </summary>
+        /// <returns>String representation of the NIC properties</returns>
+        public override string ToString()
+        {
+            return $"NIC - Manufacturer: {Manufacture}, MAC: {MacAddress}, Type: {Type}";
+        }
+    }
+    
+    /// <summary>
+    /// Enumeration for network connection types
+    /// </summary>
+    public enum NetworkType
+    {
+        /// <summary>
+        /// Ethernet connection type
+        /// </summary>
+        Ethernet,
+        
+        /// <summary>
+        /// Token Ring connection type
+        /// </summary>
+        TokenRing
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace FTPClientProject
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("FTP Client Project - NIC Class Demo");
+            Console.WriteLine("==================================");
+            
+            // Get the single instance of NIC
+            NIC nic1 = NIC.Instance;
+            
+            // Set NIC properties
+            nic1.Manufacture = "Intel Corporation";
+            nic1.MacAddress = "00:1B:21:3C:4D:5E";
+            nic1.Type = NetworkType.Ethernet;
+            
+            Console.WriteLine("NIC Instance 1:");
+            Console.WriteLine(nic1.ToString());
+            Console.WriteLine();
+            
+            // Try to get another instance (will be the same object)
+            NIC nic2 = NIC.Instance;
+            
+            Console.WriteLine("NIC Instance 2 (same object):");
+            Console.WriteLine(nic2.ToString());
+            Console.WriteLine();
+            
+            // Verify they are the same instance
+            Console.WriteLine($"Are nic1 and nic2 the same instance? {ReferenceEquals(nic1, nic2)}");
+            
+            // Change a property on nic2 and see it reflected in nic1
+            nic2.Type = NetworkType.TokenRing;
+            Console.WriteLine($"After changing nic2.Type to TokenRing:");
+            Console.WriteLine($"nic1.Type: {nic1.Type}");
+            Console.WriteLine($"nic2.Type: {nic2.Type}");
+            
+            Console.WriteLine("\nPress any key to exit...");
+            Console.ReadKey();
+        }
+    }
+}


### PR DESCRIPTION
Add a C# `NIC` class implementing the singleton pattern to represent a machine's single network card, including manufacturer, MAC address, and type.

---
<a href="https://cursor.com/background-agent?bcId=bc-afa07173-a515-4774-8844-0223b7bcf86a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-afa07173-a515-4774-8844-0223b7bcf86a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

